### PR TITLE
Use XDG_BIN_HOME instead ~/.local/bin

### DIFF
--- a/po/README.md
+++ b/po/README.md
@@ -9,20 +9,20 @@
 
 | Language | Code | Status |
 | -------- | ---- | ------ |
-| German | de | 74% |
-| Spanish | es | 77% |
-| Estonian | et | 78% |
-| Finnish | fi | 77% |
-| French | fr | 75% |
-| Italian | it | 77% |
-| Japanese | ja | 77% |
-| Lithuanian | lt | 77% |
-| Latvian | lv | 77% |
-| Norwegian Bokmål | nb | 77% |
+| German | de | 73% |
+| Spanish | es | 88% |
+| Estonian | et | 73% |
+| Finnish | fi | 73% |
+| French | fr | 73% |
+| Italian | it | 73% |
+| Japanese | ja | 73% |
+| Lithuanian | lt | 73% |
+| Latvian | lv | 73% |
+| Norwegian Bokmål | nb | 73% |
 | Dutch | nl | 100% |
-| Portuguese (Brazil) | pt_BR | 77% |
-| Swedish | sv | 76% |
-| Chinese (Simplified) | zh_CN | 80% |
+| Portuguese (Brazil) | pt_BR | 73% |
+| Swedish | sv | 73% |
+| Chinese (Simplified) | zh_CN | 73% |
 
 ## Note
 

--- a/po/app-manager.pot
+++ b/po/app-manager.pot
@@ -336,7 +336,7 @@ msgid "Cannot determine download URL from zsync URL"
 msgstr ""
 
 #: src/windows/details_window.vala:100
-msgid "⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"
+msgid "⚠️ '%s' is not in $PATH. App will not launch from the terminal"
 msgstr ""
 
 #: src/windows/details_window.vala:160
@@ -444,7 +444,7 @@ msgid "Add to $PATH"
 msgstr ""
 
 #: src/windows/details_window.vala:650
-msgid "Create a launcher in ~/.local/bin so you can run it from the terminal"
+msgid "Create a launcher in %s so you can run it from the terminal"
 msgstr ""
 
 #: src/windows/details_window.vala:711

--- a/po/de.po
+++ b/po/de.po
@@ -346,8 +346,8 @@ msgid "Cannot determine download URL from zsync URL"
 msgstr ""
 
 #: src/windows/details_window.vala:100
-msgid "⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"
-msgstr "⚠️ '~/.local/bin' ist nicht in $PATH. App startet nicht vom Terminal"
+msgid "⚠️ '%s' is not in $PATH. App will not launch from the terminal"
+msgstr "⚠️ '%s' ist nicht in $PATH. App startet nicht vom Terminal"
 
 #: src/windows/details_window.vala:160
 msgid "Show in Files"
@@ -454,9 +454,9 @@ msgid "Add to $PATH"
 msgstr "Zu $PATH hinzufügen"
 
 #: src/windows/details_window.vala:650
-msgid "Create a launcher in ~/.local/bin so you can run it from the terminal"
+msgid "Create a launcher in %s so you can run it from the terminal"
 msgstr ""
-"Erstellen Sie einen Starter in ~/.local/bin, um die App vom Terminal zu "
+"Erstellen Sie einen Starter in %s, um die App vom Terminal zu "
 "starten"
 
 #: src/windows/details_window.vala:711

--- a/po/es.po
+++ b/po/es.po
@@ -346,9 +346,9 @@ msgid "Cannot determine download URL from zsync URL"
 msgstr "No se puede determinar la URL de descarga a partir de la URL zsync"
 
 #: src/windows/details_window.vala:100
-msgid "⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"
+msgid "⚠️ '%s' is not in $PATH. App will not launch from the terminal"
 msgstr ""
-"⚠️ '~/.local/bin' no está en $PATH. La aplicación no se ejecutará desde la "
+"⚠️ '%s' no está en $PATH. La aplicación no se ejecutará desde la "
 "terminal"
 
 #: src/windows/details_window.vala:160
@@ -456,8 +456,8 @@ msgid "Add to $PATH"
 msgstr "Añadir a $PATH"
 
 #: src/windows/details_window.vala:650
-msgid "Create a launcher in ~/.local/bin so you can run it from the terminal"
-msgstr "Crear un lanzador en ~/.local/bin para ejecutarlo desde la terminal"
+msgid "Create a launcher in %s so you can run it from the terminal"
+msgstr "Crear un lanzador en %s para ejecutarlo desde la terminal"
 
 #: src/windows/details_window.vala:711
 msgid "Actions"

--- a/po/et.po
+++ b/po/et.po
@@ -345,8 +345,8 @@ msgid "Cannot determine download URL from zsync URL"
 msgstr ""
 
 #: src/windows/details_window.vala:100
-msgid "⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"
-msgstr "⚠️ '~/.local/bin' pole $PATH-is. Rakendus ei käivitu terminalist"
+msgid "⚠️ '%s' is not in $PATH. App will not launch from the terminal"
+msgstr "⚠️ '%s' pole $PATH-is. Rakendus ei käivitu terminalist"
 
 #: src/windows/details_window.vala:160
 msgid "Show in Files"
@@ -453,9 +453,9 @@ msgid "Add to $PATH"
 msgstr "Lisa $PATH-i"
 
 #: src/windows/details_window.vala:650
-msgid "Create a launcher in ~/.local/bin so you can run it from the terminal"
+msgid "Create a launcher in %s so you can run it from the terminal"
 msgstr ""
-"Loo käivitaja ~/.local/bin kausta, et saaksid seda terminalist käivitada"
+"Loo käivitaja %s kausta, et saaksid seda terminalist käivitada"
 
 #: src/windows/details_window.vala:711
 msgid "Actions"

--- a/po/fi.po
+++ b/po/fi.po
@@ -343,9 +343,9 @@ msgid "Cannot determine download URL from zsync URL"
 msgstr ""
 
 #: src/windows/details_window.vala:100
-msgid "⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"
+msgid "⚠️ '%s' is not in $PATH. App will not launch from the terminal"
 msgstr ""
-"⚠️ '~/.local/bin' ei ole $PATH-muuttujassa. Sovellus ei käynnisty päätteestä"
+"⚠️ '%s' ei ole $PATH-muuttujassa. Sovellus ei käynnisty päätteestä"
 
 #: src/windows/details_window.vala:160
 msgid "Show in Files"
@@ -452,9 +452,9 @@ msgid "Add to $PATH"
 msgstr "Lisää $PATH-muuttujaan"
 
 #: src/windows/details_window.vala:650
-msgid "Create a launcher in ~/.local/bin so you can run it from the terminal"
+msgid "Create a launcher in %s so you can run it from the terminal"
 msgstr ""
-"Luo käynnistin ~/.local/bin-kansioon, jotta voit käynnistää sen päätteestä"
+"Luo käynnistin %s-kansioon, jotta voit käynnistää sen päätteestä"
 
 #: src/windows/details_window.vala:711
 msgid "Actions"

--- a/po/fr.po
+++ b/po/fr.po
@@ -345,9 +345,9 @@ msgid "Cannot determine download URL from zsync URL"
 msgstr ""
 
 #: src/windows/details_window.vala:100
-msgid "⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"
+msgid "⚠️ '%s' is not in $PATH. App will not launch from the terminal"
 msgstr ""
-"⚠️ '~/.local/bin' n'est pas dans $PATH. L'application ne se lancera pas "
+"⚠️ '%s' n'est pas dans $PATH. L'application ne se lancera pas "
 "depuis le terminal"
 
 #: src/windows/details_window.vala:160
@@ -456,8 +456,8 @@ msgid "Add to $PATH"
 msgstr "Ajouter à $PATH"
 
 #: src/windows/details_window.vala:650
-msgid "Create a launcher in ~/.local/bin so you can run it from the terminal"
-msgstr "Créer un lanceur dans ~/.local/bin pour l'exécuter depuis le terminal"
+msgid "Create a launcher in %s so you can run it from the terminal"
+msgstr "Créer un lanceur dans %s pour l'exécuter depuis le terminal"
 
 #: src/windows/details_window.vala:711
 msgid "Actions"

--- a/po/it.po
+++ b/po/it.po
@@ -345,8 +345,8 @@ msgid "Cannot determine download URL from zsync URL"
 msgstr ""
 
 #: src/windows/details_window.vala:100
-msgid "⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"
-msgstr "⚠️ '~/.local/bin' non è in $PATH. L'app non si avvierà dal terminale"
+msgid "⚠️ '%s' is not in $PATH. App will not launch from the terminal"
+msgstr "⚠️ '%s' non è in $PATH. L'app non si avvierà dal terminale"
 
 #: src/windows/details_window.vala:160
 msgid "Show in Files"
@@ -453,8 +453,8 @@ msgid "Add to $PATH"
 msgstr "Aggiungi a $PATH"
 
 #: src/windows/details_window.vala:650
-msgid "Create a launcher in ~/.local/bin so you can run it from the terminal"
-msgstr "Crea un lanciatore in ~/.local/bin per eseguirlo dal terminale"
+msgid "Create a launcher in %s so you can run it from the terminal"
+msgstr "Crea un lanciatore in %s per eseguirlo dal terminale"
 
 #: src/windows/details_window.vala:711
 msgid "Actions"

--- a/po/ja.po
+++ b/po/ja.po
@@ -343,9 +343,9 @@ msgid "Cannot determine download URL from zsync URL"
 msgstr ""
 
 #: src/windows/details_window.vala:100
-msgid "⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"
+msgid "⚠️ '%s' is not in $PATH. App will not launch from the terminal"
 msgstr ""
-"⚠️ '~/.local/bin'が$PATHにありません。アプリはターミナルから起動できません"
+"⚠️ '%s'が$PATHにありません。アプリはターミナルから起動できません"
 
 #: src/windows/details_window.vala:160
 msgid "Show in Files"
@@ -452,8 +452,8 @@ msgid "Add to $PATH"
 msgstr "$PATHに追加"
 
 #: src/windows/details_window.vala:650
-msgid "Create a launcher in ~/.local/bin so you can run it from the terminal"
-msgstr "ターミナルから実行できるよう~/.local/binにランチャーを作成"
+msgid "Create a launcher in %s so you can run it from the terminal"
+msgstr "ターミナルから実行できるよう%sにランチャーを作成"
 
 #: src/windows/details_window.vala:711
 msgid "Actions"

--- a/po/lt.po
+++ b/po/lt.po
@@ -345,8 +345,8 @@ msgid "Cannot determine download URL from zsync URL"
 msgstr ""
 
 #: src/windows/details_window.vala:100
-msgid "⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"
-msgstr "⚠️ '~/.local/bin' nėra $PATH. Programa nebus paleista iš terminalo"
+msgid "⚠️ '%s' is not in $PATH. App will not launch from the terminal"
+msgstr "⚠️ '%s' nėra $PATH. Programa nebus paleista iš terminalo"
 
 #: src/windows/details_window.vala:160
 msgid "Show in Files"
@@ -453,8 +453,8 @@ msgid "Add to $PATH"
 msgstr "Pridėti į $PATH"
 
 #: src/windows/details_window.vala:650
-msgid "Create a launcher in ~/.local/bin so you can run it from the terminal"
-msgstr "Sukurti paleidiklį ~/.local/bin, kad galėtumėte paleisti iš terminalo"
+msgid "Create a launcher in %s so you can run it from the terminal"
+msgstr "Sukurti paleidiklį %s, kad galėtumėte paleisti iš terminalo"
 
 #: src/windows/details_window.vala:711
 msgid "Actions"

--- a/po/lv.po
+++ b/po/lv.po
@@ -344,8 +344,8 @@ msgid "Cannot determine download URL from zsync URL"
 msgstr ""
 
 #: src/windows/details_window.vala:100
-msgid "⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"
-msgstr "⚠️ '~/.local/bin' nav $PATH. Lietotne netiks palaista no termināļa"
+msgid "⚠️ '%s' is not in $PATH. App will not launch from the terminal"
+msgstr "⚠️ '%s' nav $PATH. Lietotne netiks palaista no termināļa"
 
 #: src/windows/details_window.vala:160
 msgid "Show in Files"
@@ -452,8 +452,8 @@ msgid "Add to $PATH"
 msgstr "Pievienot $PATH"
 
 #: src/windows/details_window.vala:650
-msgid "Create a launcher in ~/.local/bin so you can run it from the terminal"
-msgstr "Izveidot palaidēju ~/.local/bin, lai varētu palaist no termināļa"
+msgid "Create a launcher in %s so you can run it from the terminal"
+msgstr "Izveidot palaidēju %s, lai varētu palaist no termināļa"
 
 #: src/windows/details_window.vala:711
 msgid "Actions"

--- a/po/nb.po
+++ b/po/nb.po
@@ -344,8 +344,8 @@ msgid "Cannot determine download URL from zsync URL"
 msgstr ""
 
 #: src/windows/details_window.vala:100
-msgid "⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"
-msgstr "⚠️ '~/.local/bin' er ikke i $PATH. Appen vil ikke starte fra terminalen"
+msgid "⚠️ '%s' is not in $PATH. App will not launch from the terminal"
+msgstr "⚠️ '%s' er ikke i $PATH. Appen vil ikke starte fra terminalen"
 
 #: src/windows/details_window.vala:160
 msgid "Show in Files"
@@ -452,9 +452,9 @@ msgid "Add to $PATH"
 msgstr "Legg til i $PATH"
 
 #: src/windows/details_window.vala:650
-msgid "Create a launcher in ~/.local/bin so you can run it from the terminal"
+msgid "Create a launcher in %s so you can run it from the terminal"
 msgstr ""
-"Opprett en starter i ~/.local/bin slik at du kan kjøre den fra terminalen"
+"Opprett en starter i %s slik at du kan kjøre den fra terminalen"
 
 #: src/windows/details_window.vala:711
 msgid "Actions"

--- a/po/nl.po
+++ b/po/nl.po
@@ -337,8 +337,8 @@ msgid "Cannot determine download URL from zsync URL"
 msgstr "Kan download-URL niet bepalen uit zsync-URL"
 
 #: src/windows/details_window.vala:100
-msgid "⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"
-msgstr "⚠️ '~/.local/bin' staat niet in $PATH. De app start niet vanuit de terminal"
+msgid "⚠️ '%s' is not in $PATH. App will not launch from the terminal"
+msgstr "⚠️ '%s' staat niet in $PATH. De app start niet vanuit de terminal"
 
 #: src/windows/details_window.vala:160
 msgid "Show in Files"
@@ -445,8 +445,8 @@ msgid "Add to $PATH"
 msgstr "Toevoegen aan $PATH"
 
 #: src/windows/details_window.vala:650
-msgid "Create a launcher in ~/.local/bin so you can run it from the terminal"
-msgstr "Maak een starter in ~/.local/bin zodat je deze vanuit de terminal kunt starten"
+msgid "Create a launcher in %s so you can run it from the terminal"
+msgstr "Maak een starter in %s zodat je deze vanuit de terminal kunt starten"
 
 #: src/windows/details_window.vala:711
 msgid "Actions"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -345,9 +345,9 @@ msgid "Cannot determine download URL from zsync URL"
 msgstr ""
 
 #: src/windows/details_window.vala:100
-msgid "⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"
+msgid "⚠️ '%s' is not in $PATH. App will not launch from the terminal"
 msgstr ""
-"⚠️ '~/.local/bin' não está no $PATH. O aplicativo não será iniciado pelo "
+"⚠️ '%s' não está no $PATH. O aplicativo não será iniciado pelo "
 "terminal"
 
 #: src/windows/details_window.vala:160
@@ -455,8 +455,8 @@ msgid "Add to $PATH"
 msgstr "Adicionar ao $PATH"
 
 #: src/windows/details_window.vala:650
-msgid "Create a launcher in ~/.local/bin so you can run it from the terminal"
-msgstr "Criar um lançador em ~/.local/bin para executá-lo pelo terminal"
+msgid "Create a launcher in %s so you can run it from the terminal"
+msgstr "Criar um lançador em %s para executá-lo pelo terminal"
 
 #: src/windows/details_window.vala:711
 msgid "Actions"

--- a/po/sv.po
+++ b/po/sv.po
@@ -344,9 +344,9 @@ msgid "Cannot determine download URL from zsync URL"
 msgstr ""
 
 #: src/windows/details_window.vala:100
-msgid "⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"
+msgid "⚠️ '%s' is not in $PATH. App will not launch from the terminal"
 msgstr ""
-"⚠️ '~/.local/bin' finns inte i $PATH. Appen kommer inte att starta från "
+"⚠️ '%s' finns inte i $PATH. Appen kommer inte att starta från "
 "terminalen"
 
 #: src/windows/details_window.vala:160
@@ -454,9 +454,9 @@ msgid "Add to $PATH"
 msgstr "Lägg till i $PATH"
 
 #: src/windows/details_window.vala:650
-msgid "Create a launcher in ~/.local/bin so you can run it from the terminal"
+msgid "Create a launcher in %s so you can run it from the terminal"
 msgstr ""
-"Skapa en startare i ~/.local/bin så att du kan köra den från terminalen"
+"Skapa en startare i %s så att du kan köra den från terminalen"
 
 #: src/windows/details_window.vala:711
 msgid "Actions"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -339,8 +339,8 @@ msgid "Cannot determine download URL from zsync URL"
 msgstr ""
 
 #: src/windows/details_window.vala:100
-msgid "⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"
-msgstr "⚠️ '~/.local/bin' 不在 $PATH 中。应用无法从终端启动"
+msgid "⚠️ '%s' is not in $PATH. App will not launch from the terminal"
+msgstr "⚠️ '%s' 不在 $PATH 中。应用无法从终端启动"
 
 #: src/windows/details_window.vala:160
 msgid "Show in Files"
@@ -447,8 +447,8 @@ msgid "Add to $PATH"
 msgstr "添加到 $PATH"
 
 #: src/windows/details_window.vala:650
-msgid "Create a launcher in ~/.local/bin so you can run it from the terminal"
-msgstr "在 ~/.local/bin 创建启动器以便从终端运行"
+msgid "Create a launcher in %s so you can run it from the terminal"
+msgstr "在 %s 创建启动器以便从终端运行"
 
 #: src/windows/details_window.vala:711
 msgid "Actions"

--- a/src/core/app_constants.vala
+++ b/src/core/app_constants.vala
@@ -7,7 +7,7 @@ namespace AppManager.Core {
     public const string APPLICATIONS_DIRNAME = "Applications";
     public const string EXTRACTED_DIRNAME = ".installed";
     public const string SQUASHFS_ROOT_DIR = "squashfs-root";
-    public const string LOCAL_BIN_DIRNAME = ".local/bin";
+    public const string LOCAL_BIN_DEFAULT_DIRNAME = ".local/bin";
 
     // Background update daemon check frequency (in seconds). Default: 1 hour. One lightweight timestamp comparison
     public const uint DAEMON_CHECK_INTERVAL = 3600;

--- a/src/core/app_paths.vala
+++ b/src/core/app_paths.vala
@@ -131,9 +131,21 @@ namespace AppManager.Core {
             }
         }
 
+        /**
+         * Returns the user-specific executable directory.
+         * Follows, in order:
+         *   1. $XDG_BIN_HOME (if set and absolute)
+         *   2. $HOME/.local/bin (fallback)
+         */
         public static string local_bin_dir {
             owned get {
-                var dir = Path.build_filename(Environment.get_home_dir(), LOCAL_BIN_DIRNAME);
+                string dir;
+                var xdg_bin_home = Environment.get_variable("XDG_BIN_HOME");
+                if (xdg_bin_home != null && xdg_bin_home.strip() != "" && Path.is_absolute(xdg_bin_home.strip())) {
+                    dir = xdg_bin_home.strip();
+                } else {
+                    dir = Path.build_filename(Environment.get_home_dir(), LOCAL_BIN_DEFAULT_DIRNAME);
+                }
                 DirUtils.create_with_parents(dir, 0755);
                 return dir;
             }

--- a/src/windows/details_window.vala
+++ b/src/windows/details_window.vala
@@ -97,7 +97,7 @@ namespace AppManager {
 
             var content_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
 
-            path_banner = new Adw.Banner(_("⚠️ '~/.local/bin' is not in $PATH. App will not launch from the terminal"));
+            path_banner = new Adw.Banner(_("⚠️ '%s' is not in $PATH. App will not launch from the terminal").printf(AppPaths.local_bin_dir));
             content_box.append(path_banner);
             update_path_banner_visibility();
 
@@ -647,7 +647,7 @@ namespace AppManager {
         private Adw.SwitchRow build_path_row() {
             path_row = new Adw.SwitchRow();
             path_row.title = _("Add to $PATH");
-            path_row.subtitle = _("Create a launcher in ~/.local/bin so you can run it from the terminal");
+            path_row.subtitle = _("Create a launcher in %s so you can run it from the terminal").printf(AppPaths.local_bin_dir);
 
             var symlink_name = "";
 


### PR DESCRIPTION
Will try to use $XDG_BIN_HOME, if not set or uses relative path then will fall back to $HOME/.local/bin. Fixes #18 