### PR TITLE
Small fix so that the word “Contributors” can be

### DIFF
--- a/src/windows/main_window.vala
+++ b/src/windows/main_window.vala
@@ -1530,7 +1530,7 @@ namespace AppManager {
         public void present_about_dialog() {
             var dialog = new Adw.AboutDialog.from_appdata(APPDATA_RESOURCE, null);
             dialog.version = APPLICATION_VERSION;
-            string[] credits = { "Contributors https://github.com/kem-a/AppManager/graphs/contributors" };
+            string[] credits = { _("Contributors") + " https://github.com/kem-a/AppManager/graphs/contributors" };
             dialog.add_credit_section(_("Credits"), credits);
 
             // Load legal sections from metainfo


### PR DESCRIPTION
translated in the Credits window.
 Changes to be committed:
	modified:   src/windows/main_window.vala