### PR TITLE
Add Nix package and flake integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@ It also doesn't require FUSE to run, thanks to the [uruntime](https://github.com
 
 Simply [download](https://github.com/kem-a/AppManager/releases) latest app version, enable execute and double click to install it.
 
+## Nix / NixOS
+
+### Run without installation
+```bash
+nix run "github:kem-a/AppManager"
+```
+
+### Install permanently
+```bash
+nix profile install "github:kem-a/AppManager"
+```
+
+### NixOS / Home Manager
+```nix
+inputs.app-manager.url = "github:kem-a/AppManager";
+# then add to packages:
+inputs.app-manager.packages.x86_64-linux.default
+```
+
 ## Build
 
 <details> <summary> <H4>Install development dependencies</H4> <b>(click to open)</b> </summary>

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "AppManager - AppImage installer and manager";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }: let
+    forAllSystems = nixpkgs.lib.genAttrs [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  in {
+    packages = forAllSystems (system: {
+      app-manager = nixpkgs.legacyPackages.${system}.callPackage ./package.nix {};
+      default = self.packages.${system}.app-manager;
+    });
+
+    devShells = forAllSystems (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      default = pkgs.mkShell {
+        inputsFrom = [ self.packages.${system}.app-manager ];
+      };
+    });
+  };
+}

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('app-manager', ['vala', 'c'],
-  version: '3.5.3',
+  version: '3.6.0',
   meson_version: '>=0.64.0'
 )
 

--- a/package.nix
+++ b/package.nix
@@ -1,14 +1,13 @@
 { lib
 , stdenv
-, fetchFromGitHub
 , meson
 , ninja
 , pkg-config
 , vala
-, cmake
 , desktop-file-utils
 , wrapGAppsHook4
 , gobject-introspection
+, makeWrapper
 , gtk4
 , libadwaita
 , glib
@@ -16,28 +15,27 @@
 , libgee
 , libsoup_3
 , zstd
+, squashfsTools
+, squashfuse
+, dwarfs
+, zsync
 }:
 
 stdenv.mkDerivation(finalAttrs: {
   pname = "app-manager";
-  version = "3.5.2";
+  version = "3.5.3";
 
-  src = fetchFromGitHub {
-    owner = "kem-a";
-    repo = "AppManager";
-    rev = "410888a592bc0fc91eaa3c15b47eb5c0cbfd6321";
-    hash = "sha256-tC4kQLjlU/TzejFDAPn3WuaVV6LoFiGh4sSaEbibxFA=";
-  };
+  src = ./.;
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
     vala
-    cmake
     desktop-file-utils
     gobject-introspection
     wrapGAppsHook4
+    makeWrapper
   ];
 
   buildInputs = [
@@ -56,11 +54,27 @@ stdenv.mkDerivation(finalAttrs: {
     "-Dbundle_unsquashfs=false"
   ];
 
+  dontWrapGApps = true;
+
+  postFixup = let
+    binPath = lib.makeBinPath [
+      squashfsTools
+      squashfuse
+      dwarfs
+      zsync
+    ];
+  in ''
+    wrapProgram $out/bin/app-manager \
+      "''${gappsWrapperArgs[@]}" \
+      --prefix PATH : "${binPath}:/run/wrappers/bin"
+  '';
+
   meta = {
     description = "MacOS-style AppImage installer and manager for Linux";
     homepage = "https://github.com/kem-a/AppManager";
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];
     platforms = lib.platforms.linux;
+    mainProgram = "app-manager";
   };
 })

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, vala
+, cmake
+, desktop-file-utils
+, wrapGAppsHook4
+, gobject-introspection
+, gtk4
+, libadwaita
+, glib
+, json-glib
+, libgee
+, libsoup_3
+, zstd
+}:
+
+stdenv.mkDerivation(finalAttrs: {
+  pname = "app-manager";
+  version = "3.5.2";
+
+  src = fetchFromGitHub {
+    owner = "kem-a";
+    repo = "AppManager";
+    rev = "410888a592bc0fc91eaa3c15b47eb5c0cbfd6321";
+    hash = "sha256-tC4kQLjlU/TzejFDAPn3WuaVV6LoFiGh4sSaEbibxFA=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    vala
+    cmake
+    desktop-file-utils
+    gobject-introspection
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+    glib
+    json-glib
+    libgee
+    libsoup_3
+    zstd
+  ];
+
+  mesonFlags = [
+    "-Dbundle_dwarfs=false"
+    "-Dbundle_zsync=false"
+    "-Dbundle_unsquashfs=false"
+  ];
+
+  meta = {
+    description = "MacOS-style AppImage installer and manager for Linux";
+    homepage = "https://github.com/kem-a/AppManager";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/package.nix
+++ b/package.nix
@@ -23,7 +23,9 @@
 
 stdenv.mkDerivation(finalAttrs: {
   pname = "app-manager";
-  version = "3.5.3";
+  version = let
+  	match = builtins.match ".*version: '([0-9.]+)'.*" (builtins.readFile ./meson.build);
+  in lib.head match;
 
   src = ./.;
 

--- a/src/windows/main_window.vala
+++ b/src/windows/main_window.vala
@@ -1105,6 +1105,11 @@ namespace AppManager {
         }
 
         private bool is_fuse_installed() {
+            if (GLib.Environment.find_program_in_path("fusermount") != null ||
+                GLib.Environment.find_program_in_path("fusermount3") != null) {
+                return true;
+            }
+
             // AppImages typically require libfuse.so.2 (FUSE 2.x)
             // Check common library paths for the actual library file
             string[] lib_paths = {
@@ -1117,12 +1122,43 @@ namespace AppManager {
                 "/usr/lib/i386-linux-gnu/libfuse.so.2",
                 "/lib/x86_64-linux-gnu/libfuse.so.2",
                 "/lib/aarch64-linux-gnu/libfuse.so.2",
-                "/lib/i386-linux-gnu/libfuse.so.2"
+                "/lib/i386-linux-gnu/libfuse.so.2",
+                // Nix/NixOS paths
+                "/run/current-system/sw/lib/libfuse.so.2"
             };
 
             foreach (var path in lib_paths) {
                 if (GLib.FileUtils.test(path, FileTest.EXISTS)) {
                     return true;
+                }
+            }
+
+            string[] nix_patterns = {
+                "/nix/store/*-fuse-*/lib/libfuse.so.2",
+                "/nix/store/*-libfuse-*/lib/libfuse.so.2"
+            };
+
+            foreach (var pattern in nix_patterns) {
+                try {
+                    var glob_path = pattern.split("*")[0];
+                    var glob_suffix = pattern.split("*")[1];
+                    var dir = GLib.File.new_for_path(glob_path);
+                    if (!dir.query_exists()) continue;
+                    
+                    var enumerator = dir.enumerate_children("standard::name", 0);
+                    FileInfo? file = null;
+                    while ((file = enumerator.next_file()) != null) {
+                        var name = file.get_name();
+                        if (name.contains("fuse") && name.contains(glob_suffix)) {
+                            var child = dir.get_child(name);
+                            var libfuse_path = child.get_path() + "/lib/libfuse.so.2";
+                            if (GLib.FileUtils.test(libfuse_path, FileTest.EXISTS)) {
+                                return true;
+                            }
+                        }
+                    }
+                } catch (Error e) {
+                    // Ignore errors for non-existent paths
                 }
             }
             return false;


### PR DESCRIPTION
- Add Nix package definition (package.nix) for AppManager v3.5.2
- Create flake.nix with cross-platform support (x86_64-linux, aarch64-linux)
- Add flake.lock for reproducible builds
- Update README.md with Nix/NixOS usage instructions:
  * nix run for temporary execution
  * nix profile install for permanent installation * NixOS/Home Manager integration example

The package bundles dwarfs, zsync, and unsquashfs disabled via meson flags.

I'll work on github actions workflow to bump version and hash in package.nix