### PR TITLE
feat: auto-detect update source from AppImage metainfo homepage

### DIFF
--- a/src/core/app_image_assets.vala
+++ b/src/core/app_image_assets.vala
@@ -401,6 +401,32 @@ namespace AppManager.Core {
             return find_summary_in_dir_recursive(metainfo_root);
         }
 
+        /**
+         * Extract a homepage URL from the AppImage's embedded metainfo XML.
+         *
+         * The AppStream/metainfo spec defines <url type="homepage"> for the
+         * upstream project page. Many AppImages that do not embed an
+         * X-AppImage-Homepage key in their .desktop file or a .upd_info ELF
+         * section still ship a metainfo file with this element (e.g. KDE,
+         * GNOME, and a large part of the AppImageHub catalogue). When the
+         * homepage is a GitHub repository URL, AppManager can use it as the
+         * update source for GitHub Releases queries.
+         *
+         * Returns the first <url type="homepage"> value found across all
+         * metainfo files, or null if none is present.
+         */
+        public static string? extract_homepage_from_metainfo(string appimage_path, string temp_root, string? desktop_id_hint = null, string? app_name_hint = null) {
+            var metainfo_root = ensure_metainfo_extracted(appimage_path, temp_root);
+            // Prefer the best-matching file so we don't pick up a bundled
+            // service's metainfo instead of the app's own.
+            var best_match = find_best_metainfo_file(metainfo_root, desktop_id_hint, app_name_hint);
+            if (best_match != null) {
+                var url = parse_metainfo_homepage(best_match);
+                if (url != null) return url;
+            }
+            return find_homepage_in_dir_recursive(metainfo_root);
+        }
+
         private static string ensure_metainfo_extracted(string appimage_path, string temp_root) {
             var metainfo_root = Path.build_filename(temp_root, "metainfo");
             DirUtils.create_with_parents(metainfo_root, 0755);
@@ -956,6 +982,74 @@ namespace AppManager.Core {
                 }
             } catch (Error e) {
                 debug("Failed to parse metainfo summary %s: %s", xml_path, e.message);
+            }
+            return null;
+        }
+
+        /**
+         * Parse the first <url type="homepage"> value from a metainfo XML file.
+         * Handles both single-quoted and double-quoted attribute values and
+         * ignores other url types (bugtracker, donation, translate, …).
+         */
+        private static string? parse_metainfo_homepage(string xml_path) {
+            try {
+                string contents;
+                FileUtils.get_contents(xml_path, out contents);
+
+                // Iterate over every <url ...> element and pick the first
+                // one whose type attribute equals "homepage".
+                int search_pos = 0;
+                while (true) {
+                    var tag_start = contents.index_of("<url", search_pos);
+                    if (tag_start < 0) break;
+
+                    var tag_end = contents.index_of(">", tag_start);
+                    if (tag_end < 0) break;
+
+                    var tag = contents.substring(tag_start, tag_end - tag_start + 1);
+
+                    // Check type attribute (accept both quote styles)
+                    bool is_homepage = tag.contains("type=\"homepage\"") ||
+                                       tag.contains("type='homepage'");
+
+                    if (is_homepage) {
+                        var close_tag = "</url>";
+                        var value_start = tag_end + 1;
+                        var value_end = contents.index_of(close_tag, value_start);
+                        if (value_end > value_start) {
+                            var url = contents.substring(value_start, value_end - value_start).strip();
+                            if (url.length > 0) {
+                                debug("Found homepage in metainfo: %s -> %s", xml_path, url);
+                                return url;
+                            }
+                        }
+                    }
+
+                    search_pos = tag_end + 1;
+                }
+            } catch (Error e) {
+                debug("Failed to parse metainfo homepage %s: %s", xml_path, e.message);
+            }
+            return null;
+        }
+
+        private static string? find_homepage_in_dir_recursive(string dir_path) {
+            try {
+                var dir = Dir.open(dir_path);
+                string? name;
+                while ((name = dir.read_name()) != null) {
+                    var path = Path.build_filename(dir_path, name);
+
+                    if (FileUtils.test(path, FileTest.IS_DIR)) {
+                        var url = find_homepage_in_dir_recursive(path);
+                        if (url != null) return url;
+                    } else if (name.has_suffix(".metainfo.xml") || name.has_suffix(".appdata.xml")) {
+                        var url = parse_metainfo_homepage(path);
+                        if (url != null) return url;
+                    }
+                }
+            } catch (Error e) {
+                debug("Failed to search metainfo dir %s: %s", dir_path, e.message);
             }
             return null;
         }

--- a/src/core/installer.vala
+++ b/src/core/installer.vala
@@ -648,6 +648,31 @@ namespace AppManager.Core {
                         original_update_url = update_info;
                     }
                 }
+
+                // Metainfo homepage fallback: many AppImages (especially Electron-based
+                // ones) do not embed X-AppImage-Homepage or .upd_info, but do ship a
+                // metainfo/appdata XML file with a <url type="homepage"> element.
+                // When that URL points at a GitHub repository AppManager can use it as
+                // the update source for GitHub Releases queries, giving those apps the
+                // same automatic update detection as AppImages that embed update metadata.
+                if (original_homepage == null || original_homepage.strip() == "") {
+                    var desktop_id_hint = desktop_entry.icon;
+                    var desktop_name = desktop_entry.name;
+                    var metainfo_url = AppImageAssets.extract_homepage_from_metainfo(
+                        assets_path, temp_dir, desktop_id_hint, desktop_name);
+                    if (metainfo_url != null && metainfo_url.strip() != "") {
+                        original_homepage = metainfo_url.strip();
+                        // If the homepage is a supported update source (GitHub, GitLab…)
+                        // and no explicit update URL was found, promote it to the update
+                        // link so the updater can query it for new releases.
+                        if (original_update_url == null || original_update_url.strip() == "") {
+                            var normalized = Updater.normalize_update_url(original_homepage);
+                            if (normalized != null) {
+                                original_update_url = normalized;
+                            }
+                        }
+                    }
+                }
                 
                 var exec_value = desktop_entry.exec;
                 var original_exec_args = exec_value != null ? DesktopEntry.extract_exec_arguments(exec_value) : null;


### PR DESCRIPTION
## Problem

Many AppImages — especially Electron-based ones (Obsidian, Arduino IDE, Upscayl, ResponsivelyApp, etc.) — do not embed `X-AppImage-Homepage` in their `.desktop` file or a `.upd_info` ELF section. As a result, AppManager records no update source at install time and the updater silently skips them with `NO_UPDATE_URL`.

Users who install these apps by dragging them in see no updates detected, even when newer releases exist on GitHub.

## Root cause

The installer only reads update metadata from two sources:
1. `X-AppImage-Homepage` / `X-AppImage-UpdateURL` from the bundled `.desktop` file
2. The `.upd_info` ELF section

Electron packagers (electron-builder, etc.) set neither. However, many of these same AppImages do ship a `metainfo.xml` / `appdata.xml` file with `<url type="homepage">` — the AppStream standard field for the upstream project page.

## Fix

After the existing extraction block in the installer, fall back to reading `<url type="homepage">` from the AppImage's bundled metainfo XML (the same files already parsed for version and description). When the URL is a supported update source (GitHub, GitLab, or a direct zsync URL), promote it to `original_update_link` so the GitHub/GitLab Releases updater can query it for new releases.

Promotion respects the existing `Updater.normalize_update_url()` gate — arbitrary non-GitHub/GitLab homepages are stored as `web_page` only and do not affect update checking.

### New API in `AppImageAssets`

| Method | Visibility | Purpose |
|---|---|---|
| `extract_homepage_from_metainfo()` | `public static` | Mirrors `extract_summary_from_metainfo()` |
| `parse_metainfo_homepage()` | `private static` | Parses `<url type="homepage">` from one XML file |
| `find_homepage_in_dir_recursive()` | `private static` | Directory-walk fallback |

## Testing

Verified with `appimagetool-x86_64.AppImage` — after this change, install records `original_web_page = https://github.com/AppImage/AppImageKit` and `original_update_link = https://github.com/AppImage/AppImageKit`, which the GitHub Releases updater then uses to query for newer releases.

Apps that already embed `X-AppImage-Homepage` or `.upd_info` are unaffected (the fallback only runs when both are absent).